### PR TITLE
updated README to identify Postgres as the data store

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Todo-Backend in Sinatra
 ====================
 
-This is a simple implementation of the [Todo-Backend API spec](http://todo-backend.thepete.net/).
-
-It does not persist todos anywhere; they are just stored in a ruby Hash.
+This is a simple implementation of the [Todo-Backend API spec](http://todo-backend.thepete.net/). It persists todos in a Postgres database.
 
 It is running live at [http://todo-backend-sinatra.herokuapp.com/todos](http://todo-backend-sinatra.herokuapp.com/todos). You can [point a todo-backend client at that live instance](http://todo-backend.thepete.net/client/?http://todo-backend-sinatra.herokuapp.com/todos) to play with it. You can also [run the Todo-Backend specs against that live instance](http://todo-backend.thepete.net/specs/specs.html?http://todo-backend-sinatra.herokuapp.com/todos) to confirm that it complies with the Todo-Backend API spec.


### PR DESCRIPTION
This implementation now _does_ store todos in a database. I figured the README should be accurate.
